### PR TITLE
named arguments should be named

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -431,7 +431,7 @@ end
 function wavwrite(samples::Array, filename::String; Fs=8000, nbits=16, compression=WAVE_FORMAT_PCM)
     io = open(filename, "w")
     finalizer(io, close)
-    return wavwrite(samples, io, Fs, nbits, compression)
+    return wavwrite(samples, io, Fs=Fs, nbits=nbits, compression=compression)
 end
 
 wavwrite(y::Array, f::Real, filename::String) = wavwrite(y, filename, Fs=f)


### PR DESCRIPTION
The main function 

function wavwrite(samples::Array, io::IO; Fs=8000, nbits=16, compression=WAVE_FORMAT_PCM)

is called in 

function wavwrite(samples::Array, filename::String; Fs=8000, nbits=16, compression=WAVE_FORMAT_PCM)

as if parameters Fs etc are positional, and not named
