### PR TITLE
Add basic wavplay function in linux using PulseAudio

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -1,7 +1,9 @@
 # -*- mode: julia; -*-
 module WAV
-export wavread, wavwrite, WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
+export wavread, wavwrite, wavplay, WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
 import Base.unbox, Base.box
+
+@linux? include("wavplay.jl") : (wavplay(args...) = warn("wavplay is not currently implemented on $OS_NAME"))
 
 # The WAV specification states that numbers are written to disk in little endian form.
 write_le(stream::IO, value::Uint8) = write(stream, value)

--- a/src/wavplay.jl
+++ b/src/wavplay.jl
@@ -1,0 +1,29 @@
+
+immutable PulseSample
+    format::Int32
+    rate::Uint32
+    channels::Uint8
+end
+
+wavplay(fname) = wavplay(wavread(fname)...)
+
+function wavplay(data, Fs, args...)
+    ss = PulseSample(5,Fs,size(data,2))
+    data = convert(Array{Float32}, data)
+
+    err = Cint[0]
+    s = ccall((:pa_simple_new, "libpulse-simple"), 
+        Ptr{Void}, (Ptr{Void}, Ptr{Uint8}, Cint, Ptr{Void}, Ptr{Uint8}, 
+        Ptr{PulseSample}, Ptr{Void}, Ptr{Void}, Ptr{Cint}), 
+        0,"hey",1,0,"playback",&ss,0,0,err)
+    assert(s != C_NULL)
+
+
+    assert(0 == ccall((:pa_simple_write, "libpulse-simple"), Int32, 
+        (Ptr{Void}, Ptr{Void}, Cssize_t, Ptr{Cint}),
+        s, data, sizeof(data), err))
+
+    assert(0 == ccall((:pa_simple_drain, "libpulse-simple"), Int32, 
+        (Ptr{Void}, Ptr{Cint}), s, err))
+    nothing
+end


### PR DESCRIPTION
Under linux, it is possible to play wav files without any prerequisites using the PulseAudio simple library. In
Ubuntu I had to install libpulse-dev, but Fedora had the libpulse-simple library already installed.

This is pretty basic, but may be a good starting point.
