### PR TITLE
Added WAVArray and writemime methods

### DIFF
--- a/src/AudioDisplay.jl
+++ b/src/AudioDisplay.jl
@@ -1,0 +1,19 @@
+import Base.writemime
+
+type WAVArray{T,N}
+    Fs::Uint32
+    data::Array{T,N}
+end
+
+wavwrite(x::WAVArray, io::IO) = wavwrite(x.data, io; Fs=x.Fs)
+
+function writemime(io::IO, ::MIME"text/html", x::WAVArray)
+    buf = IOBuffer()
+    wavwrite(x, buf)
+    data = base64(bytestring(buf)) 
+    markup = """<audio controls="controls" {autoplay}>
+                <source src="data:audio/wav;base64,$data" type="audio/wav" />
+                Your browser does not support the audio element.
+                </audio>"""
+    print(io, markup)
+end

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -1,9 +1,11 @@
 # -*- mode: julia; -*-
 module WAV
-export wavread, wavwrite, wavappend, wavplay, WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
+export wavread, wavwrite, wavappend, wavplay, WAVArray, WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
 import Base.unbox, Base.box
 
 @linux? include("wavplay.jl") : (wavplay(args...) = warn("wavplay is not currently implemented on $OS_NAME"))
+
+include("AudioDisplay.jl")
 
 # The WAV specification states that numbers are written to disk in little endian form.
 write_le(stream::IO, value::Uint8) = write(stream, value)


### PR DESCRIPTION
As previously discussed in JuliaLang/IJulia.jl#247, I added a `writemime` method for playing Julia arrays as WAV files in an IJulia notebook. I created a type (now called `WAVArray`, in lack of a better name) that simply wraps an array and a corresponding sampling rate. The method `writemime(io, MIME"text/html", x::WAVArray)` will then use `wavwrite` to render the vector as a WAV file and embed it in HTML5.

Since this was implemented as a `writemime` for a specific type, any function or code that returns a `WAVArray` in the last line of a notebook cell will render the audio player. A user can optionally call `display(x::WAVArray)` to  render the audio player as well.
