### PR TITLE
add support for playing mono signals

### DIFF
--- a/src/wavplay-audioqueue.jl
+++ b/src/wavplay-audioqueue.jl
@@ -351,7 +351,10 @@ function getFormatForData(data, fs)
                                        elSize * 8)          # bits per channel
 end
 
-function wavplay(data, fs)
+
+wavplay(data::Vector, fs) = wavplay([data data], fs)
+
+function wavplay(data::Matrix, fs)
     userData = AudioQueueData(data)
     userData.aq = AudioQueueNewOutput(getFormatForData(data, fs), userData)
     for buf in allocateAllBuffers(userData)


### PR DESCRIPTION
Currently, `wavplay`ing of mono signals is not supported:

```
julia> fs = 44100;
julia> signal = sin(linspace(0, 1000pi, fs));
julia> wavplay(signal, fs)
ERROR: `sub` has no method matching sub(::Array{Float64,1}, ::(UnitRange{Int64},UnitRange{Int64}))
 in sub at subarray.jl:80
 in sub at subarray.jl:132
 in enqueueBuffer at wavplay-audioqueue.jl:190
 in wavplay at wavplay-audioqueue.jl:358
```

This pull request adds support for playing mono signals by playing the mono signals on both channels.

I do not know whether this would work for the Linux version as well, or whether this works for all sound cards. 