### PR TITLE
Add explicit `signed` conversion when loading signed negative values

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -245,6 +245,7 @@ function read_pcm_samples(io::IO, fmt::WAVFormat, subrange)
             # sign extend negative values
             if fmt.nbits > 8 && (my_sample & mask > 0)
                 my_sample |= signextend_mask
+                my_sample = signed(my_sample)
             end
             samples[i, j] = convert(eltype(samples), my_sample)
         end


### PR DESCRIPTION
On the latest master, converting an (unsigned) negative value to a signed value such as `convert(Int16, a::UInt64)`seems to  throw an InexactError.

- v0.3
```julia
julia> convert(Int16, uint(2^15) | ~unsigned(0) << 16)
-32768
```

- master
```julia
julia> convert(Int16, uint(2^15) | ~unsigned(0) << 16)
ERROR: InexactError()
 in convert at int.jl:155
```

so we need to have explicit unsigned conversion using `signed` instead of converting it directly.

- v0.3 & master
```julia
julia> convert(Int16, signed(uint(2^15) | ~unsigned(0) << 16))
-32768
```

I hope this fixes https://github.com/dancasimiro/WAV.jl/issues/21.