### PR TITLE
Fix open flags in wavappend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ generates some data, writes it to a file and then reads the data back.
 
 ```jlcon
 julia> using WAV
-julia> x = [0:7999]
+julia> x = [0:7999;]
 julia> y = sin(2 * pi * x / 8000)
 julia> wavwrite(y, "example.wav", Fs=8000)
 julia> y, fs = wavread("example.wav")

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -746,7 +746,7 @@ function wavappend(samples::AbstractArray, io::IO)
 end
 
 function wavappend(samples::AbstractArray, filename::AbstractString)
-    open(filename, "rwa") do io
+    open(filename, "a+") do io
         wavappend(samples,io)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,18 @@ let
     y, Fs = WAV.wavread(io)
 end
 
+let
+    x = [0:7999;]
+    y = sin(2 * pi * x / 8000)
+    WAV.wavwrite(y, "example.wav", Fs=8000)
+    y, Fs = WAV.wavread("example.wav")
+    y = cos(2 * pi * x / 8000)
+    WAV.wavappend(y, "example.wav")
+    y, Fs = WAV.wavread("example.wav")
+    @test length(y) == (2 * length(x))
+    rm("example.wav")
+end
+
 ## default arguments, GitHub Issue #10
 let
     tmp=rand(Float32,(10,2))


### PR DESCRIPTION
This fixes the usage of wavappend in the README example. I added a new test that exercises
the function versions that accept strings. I am not sure if travis allows file I/O.

This is github issue #35.