### PR TITLE
Fix case-insensitive `include()`

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -21,7 +21,7 @@ function __init__()
 end
 
 include("AudioDisplay.jl")
-include("WavChunk.jl")
+include("WAVChunk.jl")
 wavplay(fname) = wavplay(wavread(fname)[1:2]...)
 
 # The WAV specification states that numbers are written to disk in little endian form.


### PR DESCRIPTION
On case-sensitive filesystems, this causes problems.