### PR TITLE
Fixed bug related to updating header when using 'wavappend()'

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -761,16 +761,18 @@ function wavappend(samples::AbstractArray, io::IO)
         error("Number of channels do not match")
     end
 
+    # Compute data length of current chunk to-be-appended. 
     data_length = size(samples, 1) * fmt.block_align
-
+    # Update `chunksize`: add length of new data. 
     seek(io,4)
     write_le(io, convert(UInt32, chunk_size + data_length))
-
-    seek(io,64)
-    subchunk_size = read_le(io, UInt32)
-    seek(io,64)
-    write_le(io, convert(UInt32, subchunk_size + data_length))
-
+    # Get `subchunk2size`. 
+    seek(io,40)
+    data_length_old = read_le(io, UInt32)
+    # Update `subchunk2size`: add length of new data. 
+    seek(io,40)
+    write_le(io, convert(UInt32, data_length_old + data_length))
+    
     seekend(io)
     write_data(io, fmt, samples)
 end


### PR DESCRIPTION
Fixed bug related to updating chunk size (field: chunksize) and data size (field: subchunk2size) in function 'wavappend()'. Incorrect reading and writing of header fields fixed by (1) replacing variables in 'wavappend()' and (2) replacing parameters passed to 'seek()'. 