### PR TITLE
Fixes for Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 FileIO 0.2.0
+Compat 0.59

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 FileIO 0.2.0
-Compat 0.59
+Compat 0.62

--- a/src/AudioDisplay.jl
+++ b/src/AudioDisplay.jl
@@ -1,4 +1,5 @@
 import Base.show
+using Compat.Base64: base64encode
 
 struct WAVArray{T,N}
     Fs::Number

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -7,6 +7,7 @@ export WAVArray, WAVFormatExtension, WAVFormat
 export isextensible, isformat, bits_per_sample
 export WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
 using Compat: nothing, Nothing, undef
+import Compat: Libdl
 using FileIO
 
 function __init__()

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -6,7 +6,7 @@ export WAVChunk, WAVMarker, wav_cue_read, wav_cue_write, wav_info_write, wav_inf
 export WAVArray, WAVFormatExtension, WAVFormat
 export isextensible, isformat, bits_per_sample
 export WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
-using Compat: nothing, Nothing, undef
+using Compat: codeunits, findall, nothing, Nothing, undef
 import Compat: Libdl
 using FileIO
 

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -6,7 +6,7 @@ export WAVChunk, WAVMarker, wav_cue_read, wav_cue_write, wav_info_write, wav_inf
 export WAVArray, WAVFormatExtension, WAVFormat
 export isextensible, isformat, bits_per_sample
 export WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MULAW
-using Compat: undef
+using Compat: nothing, Nothing, undef
 using FileIO
 
 function __init__()
@@ -518,7 +518,11 @@ function read_data(io::IO, chunk_size, fmt::WAVFormat, format, subrange)
     # "format" is the format of values, while "fmt" is the WAV file level format
     convert_to_double = x -> convert(Array{Float64}, x)
 
-    if subrange === Void
+    if subrange === Nothing
+        Base.depwarn("`wavread(..., subrange=Nothing)` is deprecated, use `wavread(..., subrange=:)` instead.", :read_data)
+        subrange = (:)
+    end
+    if subrange === (:)
         # each block stores fmt.nchannels channels
         subrange = 1:convert(UInt, chunk_size / fmt.block_align)
     end
@@ -604,7 +608,7 @@ end
 make_range(subrange) = subrange
 make_range(subrange::Number) = 1:convert(Int, subrange)
 
-function wavread(io::IO; subrange=Void, format="double")
+function wavread(io::IO; subrange=(:), format="double")
     chunk_size = read_header(io)
     samples = Array{Float64, 1}()
     nbits = 0
@@ -650,7 +654,7 @@ function wavread(io::IO; subrange=Void, format="double")
     return samples, sample_rate, nbits, opt
 end
 
-function wavread(filename::AbstractString; subrange=Void, format="double")
+function wavread(filename::AbstractString; subrange=(:), format="double")
     open(filename, "r") do io
         wavread(io, subrange=subrange, format=format)
     end

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -761,18 +761,18 @@ function wavappend(samples::AbstractArray, io::IO)
         error("Number of channels do not match")
     end
 
-    # Compute data length of current chunk to-be-appended. 
+    # Compute data length of current chunk to-be-appended.
     data_length = size(samples, 1) * fmt.block_align
-    # Update `chunksize`: add length of new data. 
+    # Update `chunksize`: add length of new data.
     seek(io,4)
     write_le(io, convert(UInt32, chunk_size + data_length))
-    # Get `subchunk2size`. 
-    seek(io,40)
+    # Get `subchunk2size`.
+    seek(io, 24 + subchunk_size)
     data_length_old = read_le(io, UInt32)
-    # Update `subchunk2size`: add length of new data. 
-    seek(io,40)
+    # Update `subchunk2size`: add length of new data.
+    seek(io, 24 + subchunk_size)
     write_le(io, convert(UInt32, data_length_old + data_length))
-    
+
     seekend(io)
     write_data(io, fmt, samples)
 end

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -12,7 +12,7 @@ using FileIO
 
 function __init__()
     module_dir = dirname(@__FILE__)
-    if Libdl.find_library(["libpulse-simple"]) != ""
+    if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
         include(joinpath(module_dir, "wavplay-pulse.jl"))
     elseif Libdl.find_library(["AudioToolbox"],
                               ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""

--- a/src/WAVChunk.jl
+++ b/src/WAVChunk.jl
@@ -1,7 +1,7 @@
 """
 A RIFF chunk.
 """
-type WAVChunk
+struct WAVChunk
     id::Symbol
     data::Vector{UInt8}
 end
@@ -9,7 +9,7 @@ end
 """
 A marker in a .wav file. `start_time` and `duration` are in samples.
 """
-type WAVMarker
+mutable struct WAVMarker
     label::String
     start_time::UInt32
     duration::UInt32

--- a/src/WAVChunk.jl
+++ b/src/WAVChunk.jl
@@ -98,8 +98,8 @@ function wav_cue_read(chunks::Vector{WAVChunk})
     markers = Dict{UInt32, WAVMarker}()
 
     # See if list and cue chunks are present
-    list_chunks = chunks[find(c -> c.id == :LIST, chunks)]
-    cue_chunks = chunks[find(c -> c.id == Symbol("cue "), chunks)]
+    list_chunks = chunks[findall(c -> c.id == :LIST, chunks)]
+    cue_chunks = chunks[findall(c -> c.id == Symbol("cue "), chunks)]
 
     for l in list_chunks
         read_list(markers, l.data)
@@ -132,12 +132,12 @@ function write_marker_list(markers::Dict{UInt32, WAVMarker})
 
     # Create all the labl entries
     for (cue_id, marker) in markers
-        labl = [write32(cue_id); Vector{UInt8}(marker.label); 0x0]
+        labl = [write32(cue_id); codeunits(marker.label); 0x0]
 
         # The note and label entries must have an even number of bytes.
         # So, for the null terminated text in the label and note, we add a minimum of
         # one null terminator, but if that creates an odd number of bytes in the labl
-        # or note entry, then add a second null terminator. 
+        # or note entry, then add a second null terminator.
         if (length(labl) % 2) == 1
             labl = [labl; 0x0]
         end
@@ -171,17 +171,17 @@ function wav_info_write(tags::Dict{Symbol, String})
 
     # Create all the tag entries
     for t in keys(tags)
-        tag = [Vector{UInt8}(tags[t]); 0x0]
+        tag = [codeunits(tags[t]); 0x0]
 
         # The tag entries must have an even number of bytes.
         # So, for the null terminated text in the tag, we add a minimum of
         # one null terminator, but if that creates an odd number of bytes in the tag
-        # or note entry, then add a second null terminator. 
+        # or note entry, then add a second null terminator.
         if (length(tag) % 2) == 1
             tag = [tag; 0x0]
         end
 
-        info_data = [info_data; Vector{UInt8}(String(t)); write32(UInt32(length(tag))); tag]
+        info_data = [info_data; codeunits(String(t)); write32(UInt32(length(tag))); tag]
     end
     [WAVChunk(:LIST, info_data)]
 end
@@ -215,7 +215,7 @@ https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/RIFF.html#Info
 function wav_info_read(chunks::Vector{WAVChunk})
     tags = Dict{Symbol, String}()
 
-    list_chunks = chunks[find(c -> c.id == :LIST, chunks)]
+    list_chunks = chunks[findall(c -> c.id == :LIST, chunks)]
     for l in list_chunks
         list_data = l.data
         if list_data[1:4] == b"INFO"

--- a/src/wavplay-audioqueue.jl
+++ b/src/wavplay-audioqueue.jl
@@ -2,13 +2,13 @@
 module WAVPlay
 import ..wavplay
 
-using Compat: undef
+using Compat: Cvoid, undef
 
 const OSStatus = Int32
-const CFTypeRef = Ptr{Void}
-const CFRunLoopRef = Ptr{Void}
-const CFStringRef = Ptr{Void}
-const AudioQueueRef = Ptr{Void}
+const CFTypeRef = Ptr{Cvoid}
+const CFRunLoopRef = Ptr{Cvoid}
+const CFStringRef = Ptr{Cvoid}
+const AudioQueueRef = Ptr{Cvoid}
 
 # format IDs
 const kAudioFormatLinearPCM = # "lpcm"
@@ -63,9 +63,9 @@ end
 # Apple Core Audio Type
 mutable struct AudioQueueBuffer
     mAudioDataBytesCapacity::UInt32
-    mAudioData::Ptr{Void}
+    mAudioData::Ptr{Cvoid}
     mAudioDataByteSize::UInt32
-    mUserData::Ptr{Void}
+    mUserData::Ptr{Cvoid}
     mPacketDescriptionCapacity::UInt32
     mPacketDescription::Ptr{AudioStreamPacketDescription}
     mPacketDescriptionCount::UInt32
@@ -80,8 +80,8 @@ const AudioToolbox =
     "/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox"
 
 CFRunLoopGetCurrent() = ccall((:CFRunLoopGetCurrent, CoreFoundation), CFRunLoopRef, ())
-CFRunLoopRun() = ccall((:CFRunLoopRun, CoreFoundation), Void, ())
-CFRunLoopStop(rl) = ccall((:CFRunLoopStop, CoreFoundation), Void, (CFRunLoopRef, ), rl)
+CFRunLoopRun() = ccall((:CFRunLoopRun, CoreFoundation), Cvoid, ())
+CFRunLoopStop(rl) = ccall((:CFRunLoopStop, CoreFoundation), Cvoid, (CFRunLoopRef, ), rl)
 getCoreFoundationRunLoopDefaultMode() =
     unsafe_load(cglobal((:kCFRunLoopDefaultMode, CoreFoundation), CFStringRef))
 
@@ -177,7 +177,7 @@ function AudioQueueEnqueueBuffer(aq, bufPtr, data)
     unsafe_store!(bufPtr, buffer)
     result = ccall((:AudioQueueEnqueueBuffer, AudioToolbox),
                    OSStatus,
-                   (AudioQueueRef, AudioQueueBufferRef, UInt32, Ptr{Void}),
+                   (AudioQueueRef, AudioQueueBufferRef, UInt32, Ptr{Cvoid}),
                    aq, bufPtr, 0, C_NULL)
     if result != 0
         error("AudioQueueEnqueueBuffer failed with $result")
@@ -266,11 +266,11 @@ function AudioQueueNewOutput(format::AudioStreamBasicDescription, userData::Audi
     runLoopMode = getCoreFoundationRunLoopDefaultMode()
 
     newAudioQueue = Array{AudioQueueRef, 1}(undef, 1)
-    cCallbackProc = cfunction(playCallback, Void,
+    cCallbackProc = cfunction(playCallback, Cvoid,
                               (Ptr{AudioQueueData}, AudioQueueRef, AudioQueueBufferRef))
     result =
         ccall((:AudioQueueNewOutput, AudioToolbox), OSStatus,
-              (Ptr{AudioStreamBasicDescription}, Ptr{Void}, Ptr{AudioQueueData}, CFRunLoopRef, CFStringRef, UInt32, Ptr{AudioQueueRef}),
+              (Ptr{AudioStreamBasicDescription}, Ptr{Cvoid}, Ptr{AudioQueueData}, CFRunLoopRef, CFStringRef, UInt32, Ptr{AudioQueueRef}),
               Ref(format), cCallbackProc, Ref(userData), runLoop, runLoopMode, 0, newAudioQueue)
     if result != 0
         error("AudioQueueNewOutput failed with $result")

--- a/src/wavplay-audioqueue.jl
+++ b/src/wavplay-audioqueue.jl
@@ -2,6 +2,8 @@
 module WAVPlay
 import ..wavplay
 
+using Compat: undef
+
 const OSStatus = Int32
 const CFTypeRef = Ptr{Void}
 const CFRunLoopRef = Ptr{Void}
@@ -146,7 +148,7 @@ end
 #     audio queue buffer structure, AudioQueueBuffer, is initially set to 0.
 # @result     An OSStatus result code.
 function AudioQueueAllocateBuffer(aq)
-    newBuffer = Array{AudioQueueBufferRef, 1}(1)
+    newBuffer = Array{AudioQueueBufferRef, 1}(undef, 1)
     result =
         ccall((:AudioQueueAllocateBuffer, AudioToolbox), OSStatus,
               (AudioQueueRef, UInt32, Ptr{AudioQueueBufferRef}),
@@ -263,7 +265,7 @@ function AudioQueueNewOutput(format::AudioStreamBasicDescription, userData::Audi
     userData.runLoop = runLoop
     runLoopMode = getCoreFoundationRunLoopDefaultMode()
 
-    newAudioQueue = Array{AudioQueueRef, 1}(1)
+    newAudioQueue = Array{AudioQueueRef, 1}(undef, 1)
     cCallbackProc = cfunction(playCallback, Void,
                               (Ptr{AudioQueueData}, AudioQueueRef, AudioQueueBufferRef))
     result =

--- a/src/wavplay-audioqueue.jl
+++ b/src/wavplay-audioqueue.jl
@@ -1,6 +1,6 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import WAV.wavplay
+import ..wavplay
 
 const OSStatus = Int32
 const CFTypeRef = Ptr{Void}

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -110,7 +110,7 @@ function wavplay(data, fs)
               PA_STREAM_PLAYBACK,
               C_NULL, # Use the default device
               "wavplay", # description of stream
-              &ss,
+              Ref(ss),
               C_NULL, # Use default channel map
               C_NULL, # Use default buffering attributes
               C_NULL) # Ignore error code

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -1,6 +1,6 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import WAV.wavplay
+import ..wavplay
 
 # typedef enum pa_sample_format
 const PA_SAMPLE_U8        =  0 # Unsigned 8 Bit PCM

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -2,7 +2,7 @@
 module WAVPlay
 import ..wavplay
 
-using Compat: undef
+using Compat: Cvoid, undef
 
 # typedef enum pa_sample_format
 const PA_SAMPLE_U8        =  0 # Unsigned 8 Bit PCM
@@ -73,7 +73,7 @@ struct pa_buffer_attr
     fragsize::UInt32
 end
 
-const pa_simple = Ptr{Void}
+const pa_simple = Ptr{Cvoid}
 const LibPulseSimple = "libpulse-simple"
 const PA_STREAM_PLAYBACK = 1
 const PA_CHANNEL_MAP_AIFF = 0
@@ -120,7 +120,7 @@ function wavplay(data, fs)
 
     write_ret = ccall((:pa_simple_write, LibPulseSimple),
                       Cint,
-                      (pa_simple, Ptr{Void}, Csize_t, Ptr{Cint}),
+                      (pa_simple, Ptr{Cvoid}, Csize_t, Ptr{Cint}),
                       s, samples, sizeof(samples), C_NULL)
     if write_ret != 0
         error("pa_simple_write failed with $write_ret")
@@ -133,6 +133,6 @@ function wavplay(data, fs)
         error("pa_simple_drain failed with $drain_ret")
     end
 
-    ccall((:pa_simple_free, LibPulseSimple), Void, (pa_simple,), s)
+    ccall((:pa_simple_free, LibPulseSimple), Cvoid, (pa_simple,), s)
 end
 end # module

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -3,6 +3,7 @@ module WAVPlay
 import ..wavplay
 
 using Compat: Cvoid, undef
+import Compat: Libdl
 
 # typedef enum pa_sample_format
 const PA_SAMPLE_U8        =  0 # Unsigned 8 Bit PCM
@@ -74,7 +75,7 @@ struct pa_buffer_attr
 end
 
 const pa_simple = Ptr{Cvoid}
-const LibPulseSimple = "libpulse-simple"
+const LibPulseSimple = Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"])
 const PA_STREAM_PLAYBACK = 1
 const PA_CHANNEL_MAP_AIFF = 0
 const PA_CHANNEL_MAP_DEFAULT = PA_CHANNEL_MAP_AIFF

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -2,6 +2,8 @@
 module WAVPlay
 import ..wavplay
 
+using Compat: undef
+
 # typedef enum pa_sample_format
 const PA_SAMPLE_U8        =  0 # Unsigned 8 Bit PCM
 const PA_SAMPLE_ALAW      =  1 # 8 Bit a-Law
@@ -83,7 +85,7 @@ function wavplay(data, fs)
 
     # Manually layout the samples.
     # convert doesn't lay out the samples as pulse audio expects
-    samples = Array{Float32, 1}(size(data, 1) * size(data, 2))
+    samples = Array{Float32, 1}(undef, size(data, 1) * size(data, 2))
     idx = 1
     for i = 1:size(data, 1)
         for j = 1:size(data, 2)

--- a/src/wavplay-unsupported.jl
+++ b/src/wavplay-unsupported.jl
@@ -1,5 +1,5 @@
 # -*- mode: julia; -*-
 module WAVPlay
 import ..wavplay
-wavplay(data, fs) = warn("wavplay is not currently implemented on $OS_NAME")
+wavplay(data, fs) = warn("wavplay is not currently implemented on $(Sys.KERNEL)")
 end # module

--- a/src/wavplay-unsupported.jl
+++ b/src/wavplay-unsupported.jl
@@ -1,5 +1,5 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import WAV.wavplay
+import ..wavplay
 wavplay(data, fs) = warn("wavplay is not currently implemented on $OS_NAME")
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,7 +141,7 @@ end
 
 ## Test wavread and wavwrite
 ## Generate some wav files for writing and reading
-for fs = (8000,11025,22050,44100,48000,96000,192000), nbits = (1,7,8,9,12,16,20,24,32,64), nsamples = convert(Array{Int}, [0; logspace(1, 4, 4)]), nchans = 1:4
+for fs = (8000,11025,22050,44100,48000,96000,192000), nbits = (1,7,8,9,12,16,20,24,32,64), nsamples = [0; 10 .^ (1:4)], nchans = 1:4
     ## Test wav files
     ## The tolerance is based on the number of bits used to encode the file in wavwrite
     tol = 2.0 / (2.0^(nbits - 1))
@@ -320,7 +320,7 @@ end
 
 ## Test encoding 32 bit values
 for nchans = (1,2,4)
-    in_data_single = convert(Array{Float32}, reshape(linspace(-1.0, 1.0, 128), trunc(Int, 128 / nchans), nchans))
+    in_data_single = convert(Array{Float32}, reshape(Compat.range(-1.0, stop=1.0, length=128), trunc(Int, 128 / nchans), nchans))
     io = IOBuffer()
     WAV.wavwrite(in_data_single, io)
 
@@ -355,7 +355,7 @@ end
 
 ## Test encoding 64 bit values
 for nchans = (1,2,4)
-    in_data_single = convert(Array{Float64}, reshape(linspace(-1.0, 1.0, 128), trunc(Int, 128 / nchans), nchans))
+    in_data_single = convert(Array{Float64}, reshape(Compat.range(-1.0, stop=1.0, length=128), trunc(Int, 128 / nchans), nchans))
     io = IOBuffer()
     WAV.wavwrite(in_data_single, io)
 
@@ -389,7 +389,7 @@ for nchans = (1,2,4)
 end
 
 ### Test A-Law and Mu-Law
-for nbits = (8, 16), nsamples = convert(Array{Int}, [0; logspace(1, 4, 4)]), nchans = 1:4, fmt=(WAV.WAVE_FORMAT_ALAW, WAV.WAVE_FORMAT_MULAW)
+for nbits = (8, 16), nsamples = [0; 10 .^ (1:4)], nchans = 1:4, fmt=(WAV.WAVE_FORMAT_ALAW, WAV.WAVE_FORMAT_MULAW)
     fs = 8000.0
     tol = 2.0 / (2.0^6)
     in_data = rand(nsamples, nchans)
@@ -469,7 +469,7 @@ for nbits = (8, 16), nsamples = convert(Array{Int}, [0; logspace(1, 4, 4)]), nch
 end
 
 ### Test float formatting
-for nbits = (32, 64), nsamples = convert(Array{Int}, [0; logspace(1, 4, 4)]), nchans = 1:2, fmt=(WAV.WAVE_FORMAT_IEEE_FLOAT)
+for nbits = (32, 64), nsamples = [0; 10 .^ (1:4)], nchans = 1:2, fmt=(WAV.WAVE_FORMAT_IEEE_FLOAT)
     fs = 8000.0
     tol = 1e-6
     in_data = rand(nsamples, nchans)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@
 import WAV
 using Compat.Test
 using Compat
-using Compat: String, undef
+using Compat: findall, String, undef
 
 # These float array comparison functions are from dists.jl
 function absdiff(current::AbstractArray{T}, target::AbstractArray{T}) where T <: Real
@@ -570,8 +570,8 @@ let
     seek(io, 0)
     data, fs, nbits, ext = WAV.wavread(io)
 
-    @test length(find(c -> c.id == :LIST, ext)) == length(in_chunks)
-    list_chunks = ext[find(c -> c.id == :LIST, ext)]
+    @test length(findall(c -> c.id == :LIST, ext)) == length(in_chunks)
+    list_chunks = ext[findall(c -> c.id == :LIST, ext)]
     for (c, i) in zip(list_chunks, in_chunks)
         @test c.id == i.id
         @test c.data == i.data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 ## -*-Julia-*-
 ## Test suite for Julia's WAV module
 import WAV
-using Base.Test
+using Compat.Test
 using Compat
 using Compat: String, undef
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@
 import WAV
 using Compat.Test
 using Compat
-using Compat: findall, String, undef
+using Compat: AbstractDisplay, findall, occursin, repr, String, undef
 
 # These float array comparison functions are from dists.jl
 function absdiff(current::AbstractArray{T}, target::AbstractArray{T}) where T <: Real
@@ -619,11 +619,11 @@ let
 end
 
 ### WAVArray
-struct TestHtmlDisplay <: Display
+struct TestHtmlDisplay <: AbstractDisplay
     io::IOBuffer
 end
 function display(d::TestHtmlDisplay, mime::MIME"text/html", x)
-    print(d.io, reprmime(mime, x))
+    print(d.io, repr(mime, x))
 end
 
 let
@@ -631,7 +631,7 @@ let
     wa = WAV.WAVArray(8000, sin.(1:256 * 8000.0 / 1024));
     myio = IOBuffer()
     display(TestHtmlDisplay(myio), MIME"text/html"(), wa)
-    @test ismatch(r"audio controls", String(take!(copy(myio))))
+    @test occursin(r"audio controls", String(take!(copy(myio))))
 end
 
 ### playback

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@
 import WAV
 using Base.Test
 using Compat
-using Compat.String
+using Compat: String, undef
 
 # These float array comparison functions are from dists.jl
 function absdiff(current::AbstractArray{T}, target::AbstractArray{T}) where T <: Real
@@ -134,7 +134,7 @@ let
 end
 
 function testread(io, ::Type{T}, sz) where T <: Real
-    a = Array{T}(sz)
+    a = Array{T}(undef, sz)
     read!(io, a)
     return a
 end


### PR DESCRIPTION
This should fix (most of) the deprecations on Julia 0.7 and make it usable there again. I've only tried `wavplay` on Linux, though, so no idea whether audioqueue works. Some more remarks follow inline.

The tests still show a bunch of deprecation warnings for implicit assignment to global variables. From a cursory glance, these should be safe to ignore because the assigned values are not used in global scope. Best way to get rid of the warnings would probably be wrapping things in testsets (to introduce explicit local scopes).