### PR TITLE
A couple of performance improvements

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -28,7 +28,7 @@ wavplay(fname) = wavplay(wavread(fname)[1:2]...)
 
 # The WAV specification states that numbers are written to disk in little endian form.
 write_le(stream::IO, value) = write(stream, htol(value))
-read_le(stream::IO, x::Type) = ltoh(read(stream, x))
+read_le(stream::IO, x::Type{T}) where {T} = ltoh(read(stream, T))
 
 # used by WAVE_FORMAT_EXTENSIBLE
 struct WAVFormatExtension
@@ -268,20 +268,20 @@ function read_pcm_samples(io::IO, fmt::WAVFormat, subrange)
     samples
 end
 
-function read_ieee_float_samples(io::IO, fmt::WAVFormat, subrange, floatType)
+function read_ieee_float_samples(io::IO, fmt::WAVFormat, subrange, ::Type{floatType}) where {floatType}
     if isempty(subrange)
         return Array{floatType, 2}(undef, 0, fmt.nchannels)
     end
     nblocks = length(subrange)
-    samples = Array{floatType, 2}(undef, nblocks, fmt.nchannels)
+    samples = Array{floatType, 2}(undef, fmt.nchannels, nblocks)
     nbits = bits_per_sample(fmt)
     skip(io, convert(UInt, (first(subrange) - 1) * (nbits / 8) * fmt.nchannels))
-    for i = 1:nblocks
+    @inbounds for i = 1:nblocks
         for j = 1:fmt.nchannels
-            samples[i, j] = read_le(io, floatType)
+            samples[j, i] = read_le(io, floatType)
         end
     end
-    samples
+    copy(samples')
 end
 
 # take the loop variable type out of the loop


### PR DESCRIPTION
I found a couple of low-hanging fruit for improving the performance of reading WAV files: 

1. use `::Type{T} where T` instead of just `T` as an argument to ensure Julia specializes on that type
2. Access the samples array in column-major order
3. Add @inbounds 

More improvements should be possible, but this already gave a better than 10x speedup, so I figured I'd open a PR. 

Before (on Julia 0.7), using the test file from https://github.com/dancasimiro/WAV.jl/issues/52 :  

```julia
julia> using BenchmarkTools, WAV
julia> y = sin.((0:9999999)/48000*2pi*440);

julia> wavwrite(y, "test.wav", Fs=48000)

julia> @btime wavread("test.wav")
  4.597 s (29999537 allocations: 572.20 MiB)
```

after: 

```julia
julia> @btime wavread("test.wav")
  321.458 ms (10000049 allocations: 305.18 MiB)
```

Completely fixing #52 is almost certainly possible, but would probably require something like https://github.com/tkoolen/FastIOBuffers.jl to speed up reading Float32s from IO streams. 