### PR TITLE
fix broken incremental compilation

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -9,21 +9,23 @@ export WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_ALAW, WAVE_FORMAT_MU
 import Libdl
 using FileIO
 
-function __init__()
-    module_dir = dirname(@__FILE__)
-    if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
-        include(joinpath(module_dir, "wavplay-pulse.jl"))
-    elseif Libdl.find_library(["AudioToolbox"],
-                              ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""
-        include(joinpath(module_dir, "wavplay-audioqueue.jl"))
-    else
-        include(joinpath(module_dir, "wavplay-unsupported.jl"))
-    end
+module_dir = dirname(@__FILE__)
+if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
+    include(joinpath(module_dir, "wavplay-pulse.jl"))
+elseif Libdl.find_library(["AudioToolbox"],
+                          ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""
+    include(joinpath(module_dir, "wavplay-audioqueue.jl"))
+else
+    include(joinpath(module_dir, "wavplay-unsupported.jl"))
 end
+
+import .WAVPlay
+WAVPlay.wavplay(fname) = wavplay(wavread(fname)[1:2]...)
+
+wavplay = WAVPlay.wavplay
 
 include("AudioDisplay.jl")
 include("WAVChunk.jl")
-wavplay(fname) = wavplay(wavread(fname)[1:2]...)
 
 # The WAV specification states that numbers are written to disk in little endian form.
 write_le(stream::IO, value) = write(stream, htol(value))

--- a/src/wavplay-audioqueue.jl
+++ b/src/wavplay-audioqueue.jl
@@ -1,6 +1,5 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import ..wavplay
 
 const OSStatus = Int32
 const CFTypeRef = Ptr{Cvoid}

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -1,6 +1,5 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import ..wavplay
 
 import Libdl
 

--- a/src/wavplay-unsupported.jl
+++ b/src/wavplay-unsupported.jl
@@ -1,5 +1,4 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import ..wavplay
 wavplay(data, fs) = warn("wavplay is not currently implemented on $(Sys.KERNEL)")
 end # module


### PR DESCRIPTION
This gets rid of these precompilation warnings in Julia 1;
```
WARNING: Method definition wavplay(Any, Any) in module WAVPlay at /home/user/.julia/dev/WAV/src/wavplay-pulse.jl:83 overwritten in module WAVPlay at /home/user/.julia/dev/WAV/src/wavplay-pulse.jl:83.
WARNING: error while reinitializing value WAV.WAVPlay:
ErrorException("Cannot replace module WAVPlay during incremental precompile.")
WARNING: replacing module WAVPlay.
WARNING: replacing module WAVPlay.
               _
```
Not sure of the original reason why the functionality was in ``__init__`` instead of the top-level module, so might require further thought if this reason still applies.