### PR TITLE
Enable support for julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.7
   - 1.0
   - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 1.0
+julia 0.7
 FileIO 0.2.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly
 


### PR DESCRIPTION
This should have been done at the same time that 1.0 support was
pushed. Version 0.7 makes it easier for users to update to julia
1.0.

Fix issue #66