### PR TITLE
Remove unnecessary dunder init in module to remove spurious warnings

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -10,20 +10,18 @@ import Libdl
 using FileIO
 using Logging
 
-function __init__()
-    module_dir = dirname(@__FILE__)
-    if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
-        include(joinpath(module_dir, "wavplay-pulse.jl"))
-    elseif Libdl.find_library(["AudioToolbox"],
-                              ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""
-        include(joinpath(module_dir, "wavplay-audioqueue.jl"))
-    end
-    nothing
+
+if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
+    include(joinpath(module_dir, "wavplay-pulse.jl"))
+elseif Libdl.find_library(["AudioToolbox"],
+                          ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""
+    include("wavplay-audioqueue.jl")
+else
+    wavplay(data, fs) = @warn "wavplay is not currently implemented on $(Sys.KERNEL)"
 end
 
 include("AudioDisplay.jl")
 include("WAVChunk.jl")
-wavplay(data, fs) = @warn "wavplay is not currently implemented on $(Sys.KERNEL)"
 wavplay(fname) = wavplay(wavread(fname)[1:2]...)
 
 # The WAV specification states that numbers are written to disk in little endian form.

--- a/src/wavplay-audioqueue.jl
+++ b/src/wavplay-audioqueue.jl
@@ -1,6 +1,5 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import ..wavplay
 
 const OSStatus = Int32
 const CFTypeRef = Ptr{Cvoid}

--- a/src/wavplay-pulse.jl
+++ b/src/wavplay-pulse.jl
@@ -1,6 +1,5 @@
 # -*- mode: julia; -*-
 module WAVPlay
-import ..wavplay
 
 import Libdl
 


### PR DESCRIPTION
Hi,

I've developed a few modules that use WAV.jl, so thanks for it!

However, when I try to use them together I get a few annoying messages that keep showing up, especially when I make changes and we see precompile's happen. Let's say I need to use WAV and two packages, both of which use WAV, this is what I see

```julia
julia> using WAV

julia> using PackageEg1
WARNING: replacing module WAVPlay.

julia> using PackageEg2
[ Info: Precompiling PackageEg2 [top-level]
WARNING: Method definition wavplay(Any, Any) in module WAV at /home/nayyarv/.julia/packages/WAV/uORV0/src/WAV.jl:26 overwritten in module WAVPlay at /home/nayyarv/.julia/packages/WAV/uORV0/src/wavplay-pulse.jl:83.
WARNING: replacing module WAVPlay.
```

It was kind of annoying me, so I decided to have a fix for both.

I don't think you need to define an `__init__()` for this Module as you really only need the check what version to run at compile time. Since this is not going to change while you're in a single Julia session, removing it has it work correctly with no unnecessary errors.

The same above code works with my code being used as WAV, no unnecessary warnings/errors.

Thanks,