### PR TITLE
Don't warn about WAVPlay replacement on reimport and wavplay function redefinition on compile

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -13,10 +13,11 @@ using Logging
 function __init__()
     module_dir = dirname(@__FILE__)
     try 
-        # check we haven't already imported this function into the namespace
-        WAVPlay
+        # check we haven't already imported this package into the namespace
+        # this will throw an error otherwise
+        WAV
     catch e
-        if isa(e, InitError)
+        if isa(e, UndefVarError) && e.var == :WAV
             if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
                 include(joinpath(module_dir, "wavplay-pulse.jl"))
             elseif Libdl.find_library(["AudioToolbox"],

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -12,18 +12,26 @@ using Logging
 
 function __init__()
     module_dir = dirname(@__FILE__)
-    if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
-        include(joinpath(module_dir, "wavplay-pulse.jl"))
-    elseif Libdl.find_library(["AudioToolbox"],
-                              ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""
-        include(joinpath(module_dir, "wavplay-audioqueue.jl"))
+    try 
+        # check we haven't already imported this function into the namespace
+        WAVPlay
+    catch e
+        if isa(e, InitError)
+            if Libdl.find_library(["libpulse-simple", "libpulse-simple.so.0"]) != ""
+                include(joinpath(module_dir, "wavplay-pulse.jl"))
+            elseif Libdl.find_library(["AudioToolbox"],
+                                      ["/System/Library/Frameworks/AudioToolbox.framework/Versions/A"]) != ""
+                include(joinpath(module_dir, "wavplay-audioqueue.jl"))
+            else
+                wavplay(data, fs) = @warn "wavplay is not currently implemented on $(Sys.KERNEL)"
+            end
+        end
     end
     nothing
 end
 
 include("AudioDisplay.jl")
 include("WAVChunk.jl")
-wavplay(data, fs) = @warn "wavplay is not currently implemented on $(Sys.KERNEL)"
 wavplay(fname) = wavplay(wavread(fname)[1:2]...)
 
 # The WAV specification states that numbers are written to disk in little endian form.

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -25,6 +25,8 @@ function __init__()
             else
                 wavplay(data, fs) = @warn "wavplay is not currently implemented on $(Sys.KERNEL)"
             end
+        else
+            throw(e)
         end
     end
     nothing


### PR DESCRIPTION
As per #74,

You have runtime search for the library, but not a reimport if it already exists. This is kind of python inspired,  so let me know if you'd prefer something else.

This should be reproducible where you create two packages with WAV as a dependency and try `using` them

```julia
julia> using PackageEg1
WARNING: replacing module WAVPlay
```

Moving the defaulting warning wavplay function to the `__init__` fixes the precompile issue 
```julia
julia> using PackageEg2
[ Info: Precompiling PackageEg2 [top-level]
WARNING: Method definition wavplay(Any, Any) in module WAV at /home/nayyarv/.julia/packages/WAV/uORV0/src/WAV.jl:26 overwritten in module WAVPlay at /home/nayyarv/.julia/packages/WAV/uORV0/src/wavplay-pulse.jl:83.
WARNING: replacing module WAVPlay.
```
since it's never defined unless it needs to be (maybe this a thing you could do with older Julia)

I still believe that this should be done at compile time. What I think you could do, would be to do a check if libpulse is installed and is different and throw a warning suggesting a rebuild? That's what most other packages do in this case (from what I can tell)