### PR TITLE
Performance improvement to read_pcm_samples

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -253,7 +253,7 @@ function read_pcm_samples(io::IO, fmt::WAVFormat, subrange)
     if isempty(subrange)
         return Array{pcm_container_type(nbits), 2}(undef, 0, fmt.nchannels)
     end
-    samples = Array{UInt64, 2}(undef, length(subrange), fmt.nchannels)
+    samples = Array{UInt, 2}(undef, length(subrange), fmt.nchannels)
     sample_type = pcm_container_type(nbits)
     nbytes = ceil(Integer, nbits / 8)
     bitshift = [0x0, 0x8, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40]

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -253,8 +253,8 @@ function read_pcm_samples(io::IO, fmt::WAVFormat, subrange)
     if isempty(subrange)
         return Array{pcm_container_type(nbits), 2}(undef, 0, fmt.nchannels)
     end
-    samples = Array{pcm_container_type(nbits), 2}(undef, length(subrange), fmt.nchannels)
-    sample_type = eltype(samples)
+    samples = Array{UInt64, 2}(undef, length(subrange), fmt.nchannels)
+    sample_type = pcm_container_type(nbits)
     nbytes = ceil(Integer, nbits / 8)
     bitshift = [0x0, 0x8, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40]
     mask = UInt64(0x1) << (nbits - 1)
@@ -273,11 +273,10 @@ function read_pcm_samples(io::IO, fmt::WAVFormat, subrange)
             end
             my_sample >>= nbytes * 8 - nbits
             # sign extend negative values
-            my_sample = xor(my_sample, mask) - mask
-            samples[i, j] = convert(sample_type, signed(my_sample))
+            samples[i, j] = xor(my_sample, mask) - mask
         end
     end
-    samples
+    convert.(sample_type, signed.(samples))
 end
 
 function read_ieee_float_samples(io::IO, fmt::WAVFormat, subrange, ::Type{floatType}) where {floatType}


### PR DESCRIPTION
Uses dot broadcasting for type conversions

```Julia
y = trunc.(Int16, 10000 .* sin.((0:9999999)/48000*2pi*440))
wavwrite(y, "/tmp/test.wav", Fs=48000)

@btime y2, fs = wavread("/tmp/test.wav")
# 1.205 s (29366210 allocations: 638.83 MiB) BEFORE
# 201.300 ms (63 allocations: 267.03 MiB) AFTER
```