### PR TITLE
wavread: always read next chunk, to handle chunk padding

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -793,7 +793,7 @@ function wavread(io::IO; subrange=(:), format="double")
         end
         seek(io, nextchunk_start)
     end
-    if data_size > 0 && data_position > 0
+    if data_position != 0
         seek(io, data_position)
         if format == "size"
             return convert(Int, data_size / fmt.block_align), convert(Int, fmt.nchannels)


### PR DESCRIPTION
This is [exactly the modification of wavread suggested 2020-09-09](https://github.com/dancasimiro/WAV.jl/issues/90#issuecomment-689647232) by @Jazzdoodle in issue #90, presented here as a PR, for easier review and discussion.
