### PR TITLE
improve read_pcm_samples

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -318,8 +318,8 @@ function read_pcm_samples(io::IO, chunk_size, fmt::WAVFormat, subrange)
     if isempty(subrange)
         return Array{pcm_container_type(nbits), 2}(undef, 0, fmt.nchannels)
     end
-    samples = Array{pcm_container_type(nbits), 2}(undef, length(subrange), fmt.nchannels)
-    sample_type = eltype(samples)
+    samples = Array{UInt64, 2}(undef, length(subrange), fmt.nchannels)
+    sample_type = pcm_container_type(nbits)
     nbytes = ceil(Integer, nbits / 8)
     bitshift = [0x0, 0x8, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40]
     mask = UInt64(0x1) << (nbits - 1)
@@ -339,11 +339,10 @@ function read_pcm_samples(io::IO, chunk_size, fmt::WAVFormat, subrange)
             end
             my_sample >>= nbytes * 8 - nbits
             # sign extend negative values
-            my_sample = xor(my_sample, mask) - mask
-            samples[i, j] = convert(sample_type, signed(my_sample))
+            samples[i, j] = xor(my_sample, mask) - mask
         end
     end
-    samples
+    convert.(sample_type, signed.(samples))
 end
 
 function read_ieee_float_samples(io::IO, chunk_size, fmt::WAVFormat, subrange, ::Type{floatType}) where {floatType}

--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -313,13 +313,13 @@ end
 
 ieee_float_container_type(nbits) = (nbits == 32 ? Float32 : (nbits == 64 ? Float64 : error("$nbits bits is not supported for WAVE_FORMAT_IEEE_FLOAT.")))
 
-function read_pcm_samples(io::IO, chunk_size, fmt::WAVFormat, subrange)
+function read_pcm_samples(io::IO, chunk_size, fmt::WAVFormat, subrange,
+                          ::Type{sample_type}) where {sample_type}
     nbits = bits_per_sample(fmt)
     if isempty(subrange)
-        return Array{pcm_container_type(nbits), 2}(undef, 0, fmt.nchannels)
+        return Array{sample_type, 2}(undef, 0, fmt.nchannels)    
     end
-    samples = Array{UInt64, 2}(undef, length(subrange), fmt.nchannels)
-    sample_type = pcm_container_type(nbits)
+    samples = Array{sample_type, 2}(undef, length(subrange), fmt.nchannels)
     nbytes = ceil(Integer, nbits / 8)
     bitshift = [0x0, 0x8, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40]
     mask = UInt64(0x1) << (nbits - 1)
@@ -339,10 +339,11 @@ function read_pcm_samples(io::IO, chunk_size, fmt::WAVFormat, subrange)
             end
             my_sample >>= nbytes * 8 - nbits
             # sign extend negative values
-            samples[i, j] = xor(my_sample, mask) - mask
+            my_sample = xor(my_sample, mask) - mask
+            samples[i, j] = convert(sample_type, signed(my_sample))
         end
     end
-    convert.(sample_type, signed.(samples))
+    samples
 end
 
 function read_ieee_float_samples(io::IO, chunk_size, fmt::WAVFormat, subrange, ::Type{floatType}) where {floatType}
@@ -604,7 +605,8 @@ function read_data(io::IO, chunk_size, fmt::WAVFormat, format, subrange)
         subrange = 1:convert(UInt, chunk_size / fmt.block_align)
     end
     if isformat(fmt, WAVE_FORMAT_PCM)
-        samples = read_pcm_samples(io, chunk_size, fmt, subrange)
+        samples = read_pcm_samples(io, chunk_size, fmt, subrange,
+                                   pcm_container_type(bits_per_sample(fmt)))
         convert_to_double = x -> convert_pcm_to_double(x, bits_per_sample(fmt))
     elseif isformat(fmt, WAVE_FORMAT_IEEE_FLOAT)
         samples = read_ieee_float_samples(io, chunk_size, fmt, subrange)


### PR DESCRIPTION
Use broadcasting to reduce number of allocations.
```julia
using BenchmarkTools, WAV

path = mktempdir()
y = trunc.(Int16, 10000 .* sin.((0:9999999)/48000*2pi*440))
wavwrite(y, joinpath(path, "test.wav"), Fs=48000)
```
Before:
```julia
julia> @benchmark wavread(joinpath(path, "test.wav"); format="native")
BenchmarkTools.Trial: 
  memory estimate:  486.24 MiB
  allocs estimate:  29366204
  --------------
  minimum time:     1.229 s (1.05% GC)
  median time:      1.321 s (5.87% GC)
  mean time:        1.324 s (5.91% GC)
  maximum time:     1.426 s (10.15% GC)
  --------------
  samples:          4
  evals/sample:     1
```
After:
```julia
@benchmark wavread(joinpath(path, "test.wav"); format="native")
BenchmarkTools.Trial: 
  memory estimate:  114.44 MiB
  allocs estimate:  58
  --------------
  minimum time:     114.778 ms (0.18% GC)
  median time:      119.207 ms (3.60% GC)
  mean time:        125.500 ms (6.17% GC)
  maximum time:     188.214 ms (35.16% GC)
  --------------
  samples:          40
  evals/sample:     1
```