### PR TITLE
Fix #101, make read_tags skip extra \0 bytes

### DIFF
--- a/src/WAVChunk.jl
+++ b/src/WAVChunk.jl
@@ -222,8 +222,12 @@ function read_tag(tags::Dict{Symbol, String}, t::Vector{UInt8})
     end
     tags[tag_id] = String(t[9:(i-1)])
 
-    # Skip the null terminator
-    t[(i+1):end]
+    # Skip null terminator/s, repeat in case multiple are present
+    while t[i] == 0 && i < length(t) 
+        i += 1
+    end
+    # Return remainder of t
+    return t[i:end]
 end
 
 """


### PR DESCRIPTION
Some WAV files contain extra consecutive \0 bytes in RIFF INFO section, which causes issues if not skipped over properly. See #101 for details