### PR TITLE
Fix #101, make read_tags skip extra arbitrary bytes

### DIFF
--- a/src/WAVChunk.jl
+++ b/src/WAVChunk.jl
@@ -217,17 +217,14 @@ function read_tag(tags::Dict{Symbol, String}, t::Vector{UInt8})
     end
 
     i = 9
+    # Find first null terminator
     while t[i] != 0
         i += 1
     end
     tags[tag_id] = String(t[9:(i-1)])
 
-    # Skip null terminator/s, repeat in case multiple are present
-    while t[i] == 0 && i < length(t) 
-        i += 1
-    end
-    # Return remainder of t
-    return t[i:end]
+    # Return remainder of t, skipping all data past first null terminator
+    return t[(9+size):end]
 end
 
 """

--- a/src/WAVChunk.jl
+++ b/src/WAVChunk.jl
@@ -222,8 +222,12 @@ function read_tag(tags::Dict{Symbol, String}, t::Vector{UInt8})
     end
     tags[tag_id] = String(t[9:(i-1)])
 
-    # Skip the null terminator
-    t[(i+1):end]
+    # Skip null terminator/s, repeat in case multiple are present
+    while t[i] == 0 && i < length(t) 
+        i += 1
+    end
+    # Return remainder of t
+    return t[i:end]
 end
 
 """


### PR DESCRIPTION
An alternative pull request to #102 that tries to fix #101 for arbitrary extra bytes and not just null padded strings.

See #101 for details