### PR TITLE
Correct LibSndFile Reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ Other Julia Audio Packages
 
 [LibSndFile](https://github.com/JuliaAudio/LibSndFile.jl) is another
 Julia audio file library. It supports more file formats (including
-WAV) and implements a more powerful playback interface, all based on
-[libsndfile](http://www.mega-nerd.com/libsndfile/).
+WAV), all based on
+[libsndfile](http://www.mega-nerd.com/libsndfile/).  
+[PortAudio](https://github.com/JuliaAudio/PortAudio.jl) provides a 
+more powerful playback interface and even allows recording. 


### PR DESCRIPTION
LibSndFile does not seem to support playback anymore
(see https://github.com/JuliaAudio/LibSndFile.jl/issues/36), so I 
removed the corresponding statement. I also linked PortAudio.jl, 
which actually supports more powerful playback.