### PR TITLE
Added a seekstart() to WAV.read_header to start at the beginning of t…

### DIFF
--- a/src/WAV.jl
+++ b/src/WAV.jl
@@ -208,6 +208,8 @@ end
 
 function read_header(io::IO)
     # check if the given file has a valid RIFF header
+    # make sure we are at the beginning of the file
+    seekstart(io)
     riff = Vector{UInt8}(undef, 4)
     read!(io, riff)
     if riff !=  b"RIFF"


### PR DESCRIPTION
This is a fix for open issue #98 in which a call to `wavread` with a IOStream that is not at the beginning of the file causes an error. The fix is simple: add a `seekstart()` command at the beginning of `read_header` to go to the beginning of the file before reading the header. Since `wavread` calls `read_header`, this resets the stream to the beginning of the file when the user calls `wavread`.